### PR TITLE
Feature: Add support for view markdown document generated from backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,14 +47,18 @@
     "antd": "^4.20.7",
     "brace": "^0.11.1",
     "browser-fs-access": "^0.29.6",
+    "github-markdown-css": "^5.1.0",
     "lodash.get": "^4.4.2",
     "mousetrap": "^1.6.5",
     "path-parse": "^1.0.7",
     "protobufjs": "^6.11.2",
     "re-resizable": "^4.11.0",
     "react-ace": "^6.4.0",
+    "react-markdown": "^8.0.3",
     "react-sortable-hoc": "^2.0.0",
     "react-use": "^17.2.4",
+    "rehype-raw": "^6.1.1",
+    "remark-gfm": "^3.0.1",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-grpc-playground",
-  "version": "0.1.2-next.0",
+  "version": "0.1.2-next.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-grpc-playground",
-  "version": "0.1.1",
+  "version": "0.1.2-next.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/src/api/GrpcPlaygroundApi.ts
+++ b/src/api/GrpcPlaygroundApi.ts
@@ -22,6 +22,7 @@ export interface UploadProtoPayload {
   files: FileList | File[];
   importFor?: FileWithImports;
   fileMappings?: Record<string, string>;
+  isGenDoc?: boolean;
 }
 
 export interface UploadProtoResponse {

--- a/src/api/GrpcPlaygroundApi.ts
+++ b/src/api/GrpcPlaygroundApi.ts
@@ -15,6 +15,7 @@ export interface GRPCPlaygroundRequestOptions {
 
 export interface GetProtoPayload {
   entitySpec: EntitySpec;
+  isGenDoc?: boolean;
 }
 
 export interface UploadProtoPayload {

--- a/src/api/GrpcPlaygroundApiClient.ts
+++ b/src/api/GrpcPlaygroundApiClient.ts
@@ -75,6 +75,10 @@ export class GrpcPlaygroundApiClient implements GrpcPlaygroundApi {
       formData.append('fileMappings', JSON.stringify(payload.fileMappings));
     }
 
+    if (payload.isGenDoc !== undefined) {
+      formData.append('isGenDoc', JSON.stringify(payload.isGenDoc));
+    }
+
     const res = await this.fetchApi.fetch(
       `${await this.discoveryApi.getBaseUrl('grpc-playground')}/upload-proto/${this.entityName}`,
       {

--- a/src/api/protobuf.ts
+++ b/src/api/protobuf.ts
@@ -7,6 +7,7 @@ export interface Proto {
   filePath: string;
   imports?: PlaceholderFile[];
   protoText: string;
+  protoDoc: string;
   ast: GrpcObject;
   root: Root;
 }

--- a/src/components/App/Badge/Badge.tsx
+++ b/src/components/App/Badge/Badge.tsx
@@ -3,15 +3,17 @@ import React from 'react';
 
 interface BadgeProps {
   type: "protoFile" | "service" | "method"
+  size?: "small" | "large" 
   children: Node | string | Element
 }
 
-export function Badge({ type, children }: BadgeProps) {
+export function Badge({ type, children, size }: BadgeProps) {
 
   return (
     <div style={{
       ...styles.badge,
-      ...styles[type]
+      ...styles[type],
+      ...styles[size || 'small']
     }}>{children}</div>
   )
 }
@@ -36,4 +38,12 @@ const styles: {[key: string]: any} = {
     backgroundColor: "#2cc316",
     color: "#fff",
   },
+  large: {
+    display: 'inline-block',
+    width: '24px',
+    height: '24px', 
+    lineHeight: '24px',
+    textAlign: 'center',
+    marginTop: '4px',
+  }
 };

--- a/src/components/App/Editor/Editor.tsx
+++ b/src/components/App/Editor/Editor.tsx
@@ -6,6 +6,7 @@ import {
   setData, setEnvironment, setInteractive,
   setMetadata,
   setMetadataVisibilty,
+  setProtoDocVisibility,
   setProtoVisibility,
   setTSLCertificate,
   setUrl,
@@ -26,6 +27,7 @@ import Resizable from "re-resizable";
 import { AddressBar } from "./AddressBar";
 import { deleteEnvironment, getEnvironments, saveEnvironment } from "../../../storage/environments";
 import { ProtoInfo, Certificate, GRPCEventEmitter } from '../../../api';
+import { ProtoDocViewer } from './ProtoDocViewer';
 
 export interface EditorAction {
   [key: string]: any
@@ -57,6 +59,7 @@ export interface EditorState extends EditorRequest {
   response: EditorResponse
   metadataOpened: boolean
   protoViewVisible: boolean
+  protoDocViewVisible: boolean
   requestStreamData: string[]
   responseStreamData: EditorResponse[]
   streamCommitted: boolean
@@ -92,6 +95,7 @@ const INITIAL_STATE: EditorState = {
   },
   metadataOpened: false,
   protoViewVisible: false,
+  protoDocViewVisible: false,
   streamCommitted: false,
   tlsCertificate: undefined,
   call: undefined,
@@ -128,6 +132,9 @@ const reducer = (state: EditorState, action: EditorAction) => {
 
     case actions.SET_PROTO_VISIBILITY:
       return { ...state, protoViewVisible: action.visible };
+
+    case actions.SET_PROTO_DOC_VISIBILITY:
+      return { ...state, protoDocViewVisible: action.visible };
 
     case actions.SET_INTERACTIVE:
       return { ...state, interactive: action.interactive };
@@ -371,6 +378,14 @@ export function Editor({ protoInfo, initialRequest, onRequestChange, onEnvironme
           onClose={() => dispatch(setProtoVisibility(false))}
         />
       )}
+
+      {protoInfo && (
+        <ProtoDocViewer
+          protoInfo={protoInfo}
+          visible={state.protoDocViewVisible}
+          onClose={() => dispatch(setProtoDocVisibility(false))}
+        />
+      )}
     </div>
   )
 }
@@ -380,6 +395,7 @@ const styles = {
     width: "100%",
     height: "100%",
     position: "relative" as "relative",
+    overflow: 'hidden',
   },
   editorContainer: {
     display: "flex",

--- a/src/components/App/Editor/Options.tsx
+++ b/src/components/App/Editor/Options.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { CaretDownOutlined, FilePptOutlined, LockOutlined, UnlockOutlined } from '@ant-design/icons';
 import { Button, Tooltip, Switch, Modal, Menu, Dropdown, MenuProps } from 'antd';
-import { setInteractive, setProtoVisibility, setGrpcWeb } from './actions';
+import { setInteractive, setProtoVisibility, setGrpcWeb, setProtoDocVisibility } from './actions';
 import { EditorAction } from './Editor';
 import { useState } from "react";
 import { TLSManager } from "./TLSManager";
@@ -112,13 +112,23 @@ export function Options({ protoInfo, dispatch, grpcWebChecked, interactiveChecke
           />
         </div>
 
-        <Button
-          icon={<FilePptOutlined />}
-          type="dashed"
-          onClick={() => dispatch(setProtoVisibility(true))}
-        >
-          View Proto
-        </Button>
+        {protoInfo?.service?.proto?.protoDoc ? (
+          <Button
+            icon={<FilePptOutlined />}
+            type="dashed"
+            onClick={() => dispatch(setProtoDocVisibility(true))}
+          >
+            View Document
+          </Button>
+        ) : (
+          <Button
+            icon={<FilePptOutlined />}
+            type="dashed"
+            onClick={() => dispatch(setProtoVisibility(true))}
+          >
+            View Proto
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/App/Editor/ProtoDocViewer.tsx
+++ b/src/components/App/Editor/ProtoDocViewer.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Drawer } from 'antd';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+
+import { ProtoInfo } from '../../../api';
+
+interface ProtoDocViewerProps {
+  protoInfo: ProtoInfo
+  visible: boolean
+  onClose: () => void
+}
+
+export function ProtoDocViewer({ protoInfo, visible, onClose }: ProtoDocViewerProps) {
+
+  return (
+    <Drawer
+      title={protoInfo.service.proto.fileName.split('/').pop()}
+      className='proto-doc-drawer'
+      placement="right"
+      width='100%'
+      getContainer={false}
+      style={{ position: 'absolute' }}
+      onClose={onClose}
+      visible={visible}
+    >
+      <ReactMarkdown
+        children={protoInfo.service.proto.protoDoc}
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw]}
+        transformLinkUri={(uri: string) => uri || undefined as any}
+        className="markdown-body"
+      />
+    </Drawer>
+  );
+}

--- a/src/components/App/Editor/actions.ts
+++ b/src/components/App/Editor/actions.ts
@@ -10,6 +10,7 @@ const actions = {
   SET_METADATA: "SET_METADATA",
   SET_METADATA_VISIBILITY: "SET_METADATA_VISIBILITY",
   SET_PROTO_VISIBILITY: "SET_PROTO_VIEW",
+  SET_PROTO_DOC_VISIBILITY: "SET_PROTO_DOC_VISIBILITY",
   SET_INTERACTIVE: "SET_INTERACTIVE",
   SET_GRPC_WEB: "SET_GRPC_WEB",
   SET_REQUEST_STREAM_DATA: "SET_REQUEST_STREAM_DATA",
@@ -50,6 +51,10 @@ export function setMetadataVisibilty(visible: boolean) {
 
 export function setProtoVisibility(visible: boolean) {
   return { type: actions.SET_PROTO_VISIBILITY, visible };
+}
+
+export function setProtoDocVisibility(visible: boolean) {
+  return { type: actions.SET_PROTO_DOC_VISIBILITY, visible };
 }
 
 export function setGrpcWeb(grpcWeb: boolean) {

--- a/src/components/App/Sidebar/DocSidebar.tsx
+++ b/src/components/App/Sidebar/DocSidebar.tsx
@@ -1,0 +1,26 @@
+import { Menu } from 'antd';
+import React from 'react'
+
+import { Badge } from '../Badge/Badge';
+import { ProtoFile } from '../../../api';
+
+interface DocSidebarProps {
+  protos: ProtoFile[];
+  onProtofileSelected: (proto: ProtoFile) => void;
+}
+
+export const DocSidebar = ({ protos, onProtofileSelected }: DocSidebarProps) => {
+  if (!protos?.length) return null;
+
+  return (
+    <Menu
+      mode="inline"
+      items={protos.map(proto => ({
+        icon: <Badge type="protoFile" size='large'> P </Badge>,
+        key: proto.proto.filePath,
+        label: proto.fileName,
+        onClick: () => onProtofileSelected(proto)
+      }))}
+    />
+  )
+}

--- a/src/components/App/Sidebar/index.tsx
+++ b/src/components/App/Sidebar/index.tsx
@@ -1,1 +1,2 @@
 export * from './Sidebar';
+export * from './DocSidebar';

--- a/src/components/App/app.css
+++ b/src/components/App/app.css
@@ -196,3 +196,21 @@ a:hover {
   position: relative;
   overflow: hidden;
 }
+
+.ant-drawer-close {
+  color: #fff;
+}
+
+.proto-doc-drawer .ant-drawer-header {
+  border: none;
+}
+
+.proto-doc-drawer .ant-drawer-body {
+  padding: 0;
+}
+
+.markdown-body {
+  left: 50%;
+  padding: calc(1em + 1ex);
+  right: 0;
+}

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,1 +1,1 @@
-export { App, StandaloneApp } from './App';
+export { App, StandaloneApp, DocApp } from './App';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { grpcPlaygroundPlugin, GrpcPlaygroundPage, GrpcPlaygroundComponent } from './plugin';
+export { grpcPlaygroundPlugin, GrpcPlaygroundPage, GrpcPlaygroundComponent, GrpcDocComponent } from './plugin';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -66,3 +66,12 @@ export const GrpcPlaygroundComponent = grpcPlaygroundPlugin.provide(
     }
   }),
 );
+
+export const GrpcDocComponent = grpcPlaygroundPlugin.provide(
+  createComponentExtension({
+    name: 'GRPC Doc Plugin',
+    component: {
+      lazy: () => import('./components/App').then(m => m.DocApp)
+    }
+  }),
+);


### PR DESCRIPTION
Ref #3 
Need https://github.com/zalopay-oss/backstage-grpc-playground-backend/pull/1

### Support viewing markdown generated document from proto files

https://github.com/zalopay-oss/backstage-grpc-playground-backend/blob/dceba9498ba0c439404ee36db3928bf2d8e561ad/config.d.ts#L3-L7

When set config `grpcPlayground.document.enabled` to true, backend will generate markdown content as a string in `protoDoc` field

https://github.com/zalopay-oss/backstage-grpc-playground/blob/8f9761ca528602f2b32ebbd23d252e2ed065d4e7/src/api/protobuf.ts#L5-L13

And when `protoDoc` is present, we show "View document" instead of "View proto" button

<img width="341" alt="image" src="https://user-images.githubusercontent.com/6152718/173570836-bcb3dde8-7606-41cc-ac66-755949ec3248.png">

<img width="1661" alt="image" src="https://user-images.githubusercontent.com/6152718/173570596-f0722ab6-b238-4ac5-b096-539426e28a98.png">

### Export `GrpcDocComponent` plugin component for customizing api-doc component. 

E.g.

![image](https://user-images.githubusercontent.com/6152718/173571618-fa14020e-8a3c-471d-93e3-78e2ad8ba533.png)

