### PR TITLE
fix uploadSuccessEmitter wont emit new data

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -1,0 +1,25 @@
+export interface Config {
+  grpcPlayground?: {
+    document?: {
+      /**
+       * @visibility frontend
+       */
+      enabled?: boolean;
+
+      /**
+       * Install protoc-gen-doc from github
+       */
+      protocGenDoc?: {
+        install?: boolean;
+        version?: string;
+      };
+      /**
+       * Use cache for generated document or not
+       */
+      useCache?: {
+        enabled: boolean;
+        ttlInMinutes: number;
+      };
+    };
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-grpc-playground",
-  "version": "0.1.2",
+  "version": "0.1.3-next.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "backstage": {
     "role": "frontend-plugin"
   },
+  "configSchema": "config.d.ts",
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/src/api/sendRequest.ts
+++ b/src/api/sendRequest.ts
@@ -174,8 +174,17 @@ export class GRPCServerRequest extends EventEmitter {
           .then(async (res) => {
             if (!res) return;
 
+            // Unary
+            if (res.status === 400) {
+              const uploadProtoRes = await res.json() as UploadProtoResponse | undefined;
+
+              if (uploadProtoRes?.status === LoadProtoStatus.part) {
+                this.emit(GRPCEventType.MISSING_IMPORTS, uploadProtoRes);
+                throw new FatalError();
+              }
+            }
+
             try {
-              // Unary
               const { error, data, metaInfo } = await res.json() as GrpcResponse;
 
               if (error) {

--- a/src/components/App/ProtoProvider.tsx
+++ b/src/components/App/ProtoProvider.tsx
@@ -88,7 +88,7 @@ export function ProtoContextProvider({ children }: { children: React.ReactNode }
           onProtoUpload(res.protos);
 
           if (successEmit) {
-            protoUploadEmit(ProtoUploadAction.SUCCESS, protos);
+            protoUploadEmit(ProtoUploadAction.SUCCESS, res.protos);
           }
         }
         break;


### PR DESCRIPTION
- fix https://github.com/zalopay-oss/backstage-grpc-playground/issues/6: GrpcDocApplication will now display missing import modal when missing proto imports
- fix: `uploadSuccessEmitter` will now emit new data