### PR TITLE
Feature: support tls for sending request

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -21,5 +21,14 @@ export interface Config {
         ttlInMinutes: number;
       };
     };
+    certStore?: {
+      /**
+       * @visibility frontend
+       */
+      enabled?: boolean;
+      provider?: string;
+      secretKey?: string;
+      initVector?: string;
+    }
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-grpc-playground",
-  "version": "0.1.4",
+  "version": "0.2.0-next.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/src/api/GrpcPlaygroundApi.ts
+++ b/src/api/GrpcPlaygroundApi.ts
@@ -1,6 +1,6 @@
 import { createApiRef } from "@backstage/core-plugin-api";
 import { ProtoFile } from "./protobuf";
-import { EntitySpec, LoadProtoStatus, FileWithImports, PlaceholderFile } from "./types";
+import { EntitySpec, LoadProtoStatus, FileWithImports, PlaceholderFile, Certificate, CertFile, LoadCertStatus, CertType } from "./types";
 
 /**
  * Options you can pass into a catalog request for additional information.
@@ -40,10 +40,25 @@ export interface SendRequestPayload {
     inputs: Object;
     metadata: Object;
   };
+  tlsCertificate?: Certificate;
   methodName: string;
   serviceName: string;
   url: string;
   interactive?: boolean;
+}
+
+export interface UploadCertificatePayload {
+  files: File | FileList | File[];
+  fileMappings?: Record<string, CertFile>;
+  // type: CertType;
+}
+
+export interface UploadCertificateResponse {
+  status: LoadCertStatus;
+  certs: CertFile[];
+  certificate?: Certificate;
+  missingCerts?: CertFile[];
+  message?: string;
 }
 
 export interface SendRequestResponse extends Response { }
@@ -69,4 +84,5 @@ export interface GrpcPlaygroundApi {
   sendServerRequest: SendServerRequest;
   getProto: GetProtoRequest;
   setEntityName: (entity: string) => void;
+  uploadCertificate: (payload: UploadCertificatePayload, options?: GRPCPlaygroundRequestOptions) => Promise<UploadCertificateResponse>;
 }

--- a/src/api/GrpcPlaygroundApi.ts
+++ b/src/api/GrpcPlaygroundApi.ts
@@ -50,7 +50,7 @@ export interface SendRequestPayload {
 export interface UploadCertificatePayload {
   files: File | FileList | File[];
   fileMappings?: Record<string, CertFile>;
-  // type: CertType;
+  certificate?: Certificate;
 }
 
 export interface UploadCertificateResponse {
@@ -58,6 +58,11 @@ export interface UploadCertificateResponse {
   certs: CertFile[];
   certificate?: Certificate;
   missingCerts?: CertFile[];
+  message?: string;
+}
+
+export interface DeleteCertificateResponse {
+  ok: boolean;
   message?: string;
 }
 
@@ -84,5 +89,7 @@ export interface GrpcPlaygroundApi {
   sendServerRequest: SendServerRequest;
   getProto: GetProtoRequest;
   setEntityName: (entity: string) => void;
+  getCertificates: (options?: GRPCPlaygroundRequestOptions) => Promise<Certificate[]>;
+  deleteCertificate: (certificateId: string, options?: GRPCPlaygroundRequestOptions) => Promise<DeleteCertificateResponse>;
   uploadCertificate: (payload: UploadCertificatePayload, options?: GRPCPlaygroundRequestOptions) => Promise<UploadCertificateResponse>;
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -49,7 +49,11 @@ export interface BaseFile {
   filePath: string;
 }
 
-export interface CertFile extends BaseFile { }
+export type CertType = 'rootCert' | 'privateKey' | 'certChain';
+
+export interface CertFile extends BaseFile {
+  type: CertType;
+ }
 
 export interface PlaceholderFile extends FileWithImports {
   isPreloaded?: boolean;
@@ -110,4 +114,10 @@ export enum LoadProtoStatus {
   ok = 1,
   fail = -1,
   part = 0
+}
+
+export enum LoadCertStatus {
+  ok = 3,
+  fail = 4,
+  part = 5
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -37,6 +37,7 @@ export interface EditorRequest {
 }
 
 export interface Certificate {
+  id?: string;
   rootCert: CertFile;
   privateKey?: CertFile;
   certChain?: CertFile;

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -92,8 +92,8 @@ const GrpcPlaygroundApplication: React.FC<GrpcPlaygroundApplicationProps> = ({ a
   } = useProtoContext()!;
 
   const {
-    selectedCertifcate,
-    missingCerts,
+    missingCertificate,
+    missingCertFiles,
     handleImportCert,
     modalMissingCertsOpen,
     ignoreCurrentMissingCert,
@@ -253,8 +253,8 @@ const GrpcPlaygroundApplication: React.FC<GrpcPlaygroundApplicationProps> = ({ a
     handleImportCert(
       grpcPlaygroundApi,
       undefined,
-      missingCerts,
-      selectedCertifcate,
+      missingCertFiles,
+      missingCertificate,
     );
   }
 
@@ -388,12 +388,12 @@ const GrpcPlaygroundApplication: React.FC<GrpcPlaygroundApplicationProps> = ({ a
               onCancel={ignoreCurrentMissingCert}
               visible={modalMissingCertsOpen}
             >
-              {missingCerts.length ? (
+              {missingCertFiles.length ? (
                 <>
                   Missing these files
                   <List
                     bordered={false}
-                    dataSource={missingCerts}
+                    dataSource={missingCertFiles}
                     renderItem={item => (
                       <List.Item>
                         <FileOutlined style={{ marginRight: 10 }} />

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -531,8 +531,8 @@ const GrpcDocApplication: React.FC<GrpcPlaygroundApplicationProps> = ({ appId, s
 
     if (isGenDoc) {
       // eslint-disable-next-line prefer-const
-      const handlerId = addUploadedListener(undefined, protos => {
-        removeUploadedListener(undefined, handlerId!);
+      const handlerId = addUploadedListener(protos => {
+        removeUploadedListener(handlerId!);
 
         if (protos?.length) {
           // Select first file to display doc

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -55,6 +55,7 @@ import { arrayMoveImmutable as arrayMove } from '../../utils'
 import { Store } from '../../storage/Store';
 
 import './app.css';
+import { CertificateContextProvider, useCertificateContext } from './CertificateProvider';
 
 function combineTargetToUrl(target: GRPCTargetInfo): string {
   if (!target.port) {
@@ -89,6 +90,15 @@ const GrpcPlaygroundApplication: React.FC<GrpcPlaygroundApplicationProps> = ({ a
     importFor,
     ignoreCurrentMissingImport,
   } = useProtoContext()!;
+
+  const {
+    selectedCertifcate,
+    missingCerts,
+    handleImportCert,
+    modalMissingCertsOpen,
+    ignoreCurrentMissingCert,
+    toggleModalMissingCerts,
+  } = useCertificateContext()!;
 
   const grpcPlaygroundApi = useApi(grpcPlaygroundApiRef);
   const configApi = useApi(configApiRef);
@@ -237,6 +247,17 @@ const GrpcPlaygroundApplication: React.FC<GrpcPlaygroundApplicationProps> = ({ a
     openFileUpload();
   }
 
+  const onClickOpenCertFile = () => {
+    toggleModalMissingCerts();
+
+    handleImportCert(
+      grpcPlaygroundApi,
+      undefined,
+      missingCerts,
+      selectedCertifcate,
+    );
+  }
+
   const onClickOpenDirectory = () => {
     toggleModalMissingImports();
     openFileUpload(true);
@@ -351,6 +372,37 @@ const GrpcPlaygroundApplication: React.FC<GrpcPlaygroundApplicationProps> = ({ a
                 </>
               ) : null}
 
+            </Modal>
+
+            <Modal
+              footer={[
+                <Button key="open-file" icon={<FileAddOutlined />} type="primary" onClick={onClickOpenCertFile}>
+                  Import file
+                </Button>,
+                <Button key="back" danger icon={<StopOutlined />} onClick={ignoreCurrentMissingCert}>
+                  Ignore
+                </Button>,
+              ]}
+              title="Missing certificate files"
+              destroyOnClose
+              onCancel={ignoreCurrentMissingCert}
+              visible={modalMissingCertsOpen}
+            >
+              {missingCerts.length ? (
+                <>
+                  Missing these files
+                  <List
+                    bordered={false}
+                    dataSource={missingCerts}
+                    renderItem={item => (
+                      <List.Item>
+                        <FileOutlined style={{ marginRight: 10 }} />
+                        {item.filePath}
+                      </List.Item>
+                    )}
+                  />
+                </>
+              ) : null}
             </Modal>
           </Layout.Content>
         </Layout>
@@ -589,9 +641,11 @@ const GrpcDocApplication: React.FC<GrpcPlaygroundApplicationProps> = ({ appId, s
 export function StandaloneApp() {
   return (
     <ProtoContextProvider>
-      <GrpcPlaygroundApplication
-        appId={DEFAULT_APP_ID}
-      />
+      <CertificateContextProvider>
+        <GrpcPlaygroundApplication
+          appId={DEFAULT_APP_ID}
+        />
+      </CertificateContextProvider>
     </ProtoContextProvider>
   )
 }
@@ -614,10 +668,12 @@ export function App() {
 
   return (
     <ProtoContextProvider>
-      <GrpcPlaygroundApplication
-        appId={entity?.metadata?.name || DEFAULT_APP_ID}
-        spec={entity?.spec as unknown as (RawEntitySpec | undefined)}
-      />
+      <CertificateContextProvider>
+        <GrpcPlaygroundApplication
+          appId={entity?.metadata?.name || DEFAULT_APP_ID}
+          spec={entity?.spec as unknown as (RawEntitySpec | undefined)}
+        />
+      </CertificateContextProvider>
     </ProtoContextProvider>
   )
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -530,10 +530,9 @@ const GrpcDocApplication: React.FC<GrpcPlaygroundApplicationProps> = ({ appId, s
     const isGenDoc = true;
 
     if (isGenDoc) {
-      let handlerId: string | undefined;
       // eslint-disable-next-line prefer-const
-      handlerId = addUploadedListener(protos => {
-        removeUploadedListener(handlerId!);
+      const handlerId = addUploadedListener(undefined, protos => {
+        removeUploadedListener(undefined, handlerId!);
 
         if (protos?.length) {
           // Select first file to display doc

--- a/src/components/App/CertificateProvider.tsx
+++ b/src/components/App/CertificateProvider.tsx
@@ -3,7 +3,7 @@ import { notification } from "antd";
 import { fileOpen, FileWithHandle } from "browser-fs-access";
 import React, { PropsWithChildren, useContext, useEffect, useRef, useState } from "react";
 import { CertType, Certificate, UploadCertificateResponse, CertFile, GrpcPlaygroundApi, LoadCertStatus, grpcPlaygroundApiRef } from "../../api";
-import { isSameCertificate, serverCertificate } from "../../utils/certificates";
+import { isSameCertificate, serverCertificate, wellKnownCertExtensions, wellKnownPKFileExtensions } from "../../utils/certificates";
 import { getTLSList as getTLSListLocal, storeTLSList as storeTLSListLocal } from "../../storage";
 import useEventEmitter, { EventHandler } from "../../utils/useEventEmitter";
 
@@ -201,8 +201,6 @@ export function CertificateContextProvider({ children }: PropsWithChildren<{}>) 
        * Mapping by name
        */
       let fileMappings: Record<string, CertFile>;
-      // const certificate = await importRootCert();
-      // const files: any = await fileOpen(getFileOpenPropsByType(type));
       const files = await fileOpen(getFileOpenPropsByType(singleUploadType ?? 'multiple'));
 
       if (singleUploadType) {
@@ -302,15 +300,19 @@ function getFileOpenPropsByType(type: CertType | 'multiple') {
   return {
     'rootCert': {
       id: 'root-cert',
+      extensions: wellKnownCertExtensions,
     },
     'privateKey': {
       id: 'private-key',
+      extensions: wellKnownPKFileExtensions,
     },
     'certChain': {
       id: 'cert-chain',
+      extensions: wellKnownCertExtensions,
     },
     multiple: {
       id: 'multiple-certs',
+      extensions: wellKnownCertExtensions.concat(wellKnownPKFileExtensions),
       multiple: true,
     }
   }[type];

--- a/src/components/App/CertificateProvider.tsx
+++ b/src/components/App/CertificateProvider.tsx
@@ -150,10 +150,10 @@ export function CertificateContextProvider({ children }: PropsWithChildren<{}>) 
 
   function removeUploadedListener(certificate: Certificate, handlerId: string) {
     removeEventListener(CertUploadAction.SUCCESS, handlerId);
-    setCurrentUploadedListener(certificate, undefined);
+    setCurrentUploadedListener(certificate);
   }
 
-  function setCurrentUploadedListener(certificate: Certificate, handlerId: string | undefined) {
+  function setCurrentUploadedListener(certificate: Certificate, handlerId?: string) {
     const rootCertPath = certificate.rootCert.filePath;
     currentUploadedListener.current[rootCertPath] = handlerId;
   };

--- a/src/components/App/CertificateProvider.tsx
+++ b/src/components/App/CertificateProvider.tsx
@@ -1,0 +1,299 @@
+import { notification } from "antd";
+import { fileOpen, FileWithHandle } from "browser-fs-access";
+import React, { PropsWithChildren, useContext, useEffect, useRef, useState } from "react";
+import { CertType, Certificate, UploadCertificateResponse, CertFile, GrpcPlaygroundApi, LoadCertStatus } from "../../api";
+import { getTLSList, storeTLSList } from "../../storage";
+import useEventEmitter, { EventHandler } from "../../utils/useEventEmitter";
+
+export type CertificateContextType = {
+  selectedCertifcate?: Certificate;
+  certs: Certificate[];
+  setCerts: (props: Certificate[]) => void;
+  addUploadedListener: (handler: (certificate: Certificate, cert: CertFile) => void) => string;
+  removeUploadedListener: (handlerId: string) => void;
+  handleMissingCert: () => void;
+  handleCertResult: (res: UploadCertificateResponse, tlsSelected: Certificate, successEmit?: boolean) => void;
+  toggleModalMissingCerts: () => void;
+  handleImportCert: (
+    api: GrpcPlaygroundApi,
+    type?: CertType,
+    missing?: CertFile[],
+    certificate?: Certificate
+  ) => Promise<Certificate | undefined>;
+  modalMissingCertsOpen: boolean;
+  missingCerts: CertFile[];
+  ignoreCurrentMissingCert: () => void;
+}
+
+export enum CertUploadAction {
+  SUCCESS = 'success',
+  FAILED = 'failed',
+}
+
+export const CertificateContext = React.createContext<CertificateContextType | null>(null);
+
+export function useCertificateContext() {
+  return useContext(CertificateContext);
+}
+
+export function CertificateContextProvider({ children }: PropsWithChildren<{}>) {
+  const [certs, setStateCerts] = useState<Certificate[]>([]);
+  const [modalMissingCertsOpen, setModalMissingCertsOpen] = useState(false);
+  const selectedCertifcate = useRef<Certificate | undefined>(undefined);
+
+  const missingCerts = React.useRef<CertFile[]>([]);
+
+  const { emit: certUploadEmit, addEventListener, removeEventListener } = useEventEmitter('cert-upload');
+
+  useEffect(() => {
+    setCerts(getTLSList());
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  
+  function setCerts(newCerts: Certificate[]) {
+    setStateCerts(newCerts);
+    storeTLSList(newCerts);
+  }
+
+  const toggleModalMissingCerts = () => {
+    setModalMissingCertsOpen(o => !o);
+  }
+
+  function handleMissingCert() {
+    const [missingFor] = missingCerts.current || [];
+    if (!missingFor) return;
+
+    toggleModalMissingCerts();
+  }
+
+  const handleCertResult = (res: UploadCertificateResponse, tlsSelected?: Certificate, successEmit?: boolean) => {
+    const onCertUpload = handleCertUpload(setCerts, certs);
+
+    if (res.certs) {
+      if (missingCerts.current.length) {
+        missingCerts.current = missingCerts.current.filter(current => {
+          return !res.certs.find(resolved => resolved.filePath === current.filePath);
+        });
+      }
+    }
+
+    if (res.certificate) {
+      selectedCertifcate.current = res.certificate;
+    }
+
+    switch (res?.status) {
+      case LoadCertStatus.part: {
+        if (res.missingCerts?.length) {
+          if (res.certs) {
+            onCertUpload(res.certs, tlsSelected);
+          }
+
+          // Merge missing certs
+          const map = new Map<string, CertFile>();
+          const addToMap = (cert: CertFile) => map.set(cert.filePath, cert);
+
+          missingCerts.current.concat(res.missingCerts).forEach(addToMap);
+          missingCerts.current = Array.from(map.values());
+        }
+        break;
+      }
+      case LoadCertStatus.ok:
+        if (res.certs) {
+          onCertUpload(res.certs, tlsSelected);
+
+          if (successEmit && !missingCerts.current.length) {
+            certUploadEmit(CertUploadAction.SUCCESS, tlsSelected, res.certs);
+          }
+        }
+        break;
+
+      default:
+      case LoadCertStatus.fail:
+        onCertUpload([], tlsSelected, new Error(res.message || 'Unknown error'));
+        break;
+    }
+
+    if (missingCerts.current.length) {
+      // still missing imports
+      handleMissingCert();
+    }
+  }
+
+  const addUploadedListener = (handler: EventHandler) => {
+    return addEventListener(CertUploadAction.SUCCESS, handler);
+  }
+
+  const removeUploadedListener = (handlerId: string) => {
+    removeEventListener(CertUploadAction.SUCCESS, handlerId);
+  }
+
+  const ignoreCurrentMissingCert = () => {
+    missingCerts.current = [];
+
+    toggleModalMissingCerts();
+
+    if (missingCerts.current.length) {
+      // 100ms is for current modalMissingImport to finish its closing animation
+      setTimeout(() => {
+        handleMissingCert();
+      }, 100);
+    }
+  }
+
+  async function handleImportCert(
+    api: GrpcPlaygroundApi,
+    singleUploadType?: CertType,
+    missings?: CertFile[],
+    certificate?: Certificate,
+  ): Promise<Certificate | undefined> {
+    try {
+      /**
+       * Mapping by name
+       */
+      let fileMappings: Record<string, CertFile>;
+      // const certificate = await importRootCert();
+      // const files: any = await fileOpen(getFileOpenPropsByType(type));
+      const files = await fileOpen(getFileOpenPropsByType(singleUploadType ?? 'multiple'));
+
+      if (singleUploadType) {
+        // Single upload
+        const file = files as FileWithHandle;
+
+        fileMappings = {
+          [file.name]: {
+            fileName: file.name,
+            filePath: [file.webkitRelativePath, file.name].filter(Boolean).join('/'),
+            type: singleUploadType,
+          }
+        };
+      } else {
+        fileMappings = (files as FileWithHandle[]).reduce((acc: typeof fileMappings, file: FileWithHandle) => {
+          const match = missings?.find(f => f.fileName === file.name);
+
+          if (match) {
+            acc[file.name] = {
+              filePath: match.filePath,
+              fileName: match.fileName,
+              type: match.type
+            };
+          }
+
+          return acc;
+        }, {} as typeof fileMappings);
+      }
+
+      const certificateRes = await api.uploadCertificate({
+        files: files as any,
+        fileMappings,
+      });
+
+
+      handleCertResult(certificateRes, certificate, true);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log('OUTPUT ~ CertificateContextProvider ~ err', e);
+      // No file selected.
+    }
+
+    return certificate;
+  }
+
+  return (
+    <CertificateContext.Provider
+      value={{
+        certs,
+        setCerts,
+        selectedCertifcate: selectedCertifcate.current,
+        handleMissingCert,
+        handleCertResult,
+        addUploadedListener,
+        removeUploadedListener,
+        toggleModalMissingCerts,
+        modalMissingCertsOpen,
+        handleImportCert,
+        ignoreCurrentMissingCert,
+        missingCerts: missingCerts.current,
+      }}
+    >
+      {children}
+    </CertificateContext.Provider>
+  )
+}
+
+function getFileOpenPropsByType(type: CertType | 'multiple') {
+  return {
+    'rootCert': {
+      id: 'root-cert',
+      extensions: ['.crt'],
+    },
+    'privateKey': {
+      id: 'private-key',
+    },
+    'certChain': {
+      id: 'cert-chain',
+    },
+    multiple: {
+      id: 'multiple-certs',
+      multiple: true,
+    }
+  }[type];
+}
+
+/**
+ *
+ * @param setCerts
+ * @param certs
+ */
+export function handleCertUpload(setCerts: React.Dispatch<Certificate[]>, certs: Certificate[]) {
+  return function (newCerts: CertFile[], selectedCertifcate?: Certificate, err?: Error) {
+    if (err) {
+      notification.error({
+        message: "Error while importing certificates",
+        description: err.message,
+        duration: 5,
+        placement: "bottomLeft",
+        style: {
+          width: "89%",
+          wordBreak: "break-all",
+        }
+      });
+    }
+
+    if (newCerts.length) {
+      let appCerts = [...certs];
+
+      if (selectedCertifcate) {
+        // Upload private key or cert chain
+        appCerts = certs.map(cert => {
+          if (cert.rootCert!.filePath !== selectedCertifcate.rootCert.filePath) {
+            return cert;
+          }
+
+          const updatedCert = { ...cert };
+
+          for (const newCert of newCerts) {
+            updatedCert[newCert.type] = {
+              ...newCert,
+              // certificate: selectedCertifcate,
+            };
+          }
+
+          return updatedCert;
+        });
+      } else {
+        // New certificate
+        const newCertificate = newCerts.reduce((acc, cert) => {
+          acc[cert.type] = cert;
+
+          return acc;
+        }, {} as Certificate);
+
+        appCerts.push(newCertificate);
+      }
+
+      // eslint-disable-next-line no-console
+      console.log('OUTPUT ~ appCerts', appCerts);
+      setCerts(appCerts);
+    }
+  }
+}

--- a/src/components/App/Editor/PlayButton.tsx
+++ b/src/components/App/Editor/PlayButton.tsx
@@ -82,14 +82,14 @@ export const makeRequest = ({ dispatch, state, protoInfo, sendServerRequest, pro
     protoContext.handleProtoResult(uploadProtoRes);
 
     // eslint-disable-next-line prefer-const
-    const handlerId = protoContext.addUploadedListener(protoInfo, protos => {
-      protoContext.removeUploadedListener(protoInfo, handlerId);
+    const handlerId = protoContext.addUploadedListener(protos => {
+      protoContext.removeUploadedListener(handlerId, protoInfo);
 
       if (protos.find(p => p.proto.filePath === protoInfo.service.proto.filePath)) {
         // Re-send
         grpcRequest.send();
       }
-    })
+    }, protoInfo);
   });
 
   grpcRequest.on(GRPCEventType.MISSING_CERTS, (uploadProtoRes: UploadCertificateResponse) => {

--- a/src/components/App/Editor/PlayButton.tsx
+++ b/src/components/App/Editor/PlayButton.tsx
@@ -82,8 +82,8 @@ export const makeRequest = ({ dispatch, state, protoInfo, sendServerRequest, pro
     protoContext.handleProtoResult(uploadProtoRes);
 
     // eslint-disable-next-line prefer-const
-    const handlerId = protoContext.addUploadedListener(protos => {
-      protoContext.removeUploadedListener(handlerId);
+    const handlerId = protoContext.addUploadedListener(protoInfo, protos => {
+      protoContext.removeUploadedListener(protoInfo, handlerId);
 
       if (protos.find(p => p.proto.filePath === protoInfo.service.proto.filePath)) {
         // Re-send

--- a/src/components/App/ProtoProvider.tsx
+++ b/src/components/App/ProtoProvider.tsx
@@ -8,8 +8,8 @@ export type ProtoContextType = {
   protos: ProtoFile[];
   setProtos: (props: ProtoFile[]) => void;
   handleProtoResult: (res: UploadProtoResponse, successEmit?: boolean) => void;
-  addUploadedListener: (protoInfo: ProtoInfo | undefined, handler: (protos: ProtoFile[]) => void) => string;
-  removeUploadedListener: (protoInfo: ProtoInfo | undefined, handlerId: string) => void;
+  addUploadedListener: (handler: (protos: ProtoFile[]) => void, protoInfo?: ProtoInfo) => string;
+  removeUploadedListener: (handlerId: string, protoInfo?: ProtoInfo) => void;
   handleMissingImport: () => void;
   toggleModalMissingImports: () => void;
   modalMissingImportsOpen: boolean;
@@ -107,7 +107,7 @@ export function ProtoContextProvider({ children }: { children: React.ReactNode }
   }
 
 
-  const addUploadedListener = (proto: ProtoInfo | undefined, handler: EventHandler) => {
+  const addUploadedListener = (handler: EventHandler, proto?: ProtoInfo) => {
     if (proto) {
       const currentListener = getCurrentUploadedListener(proto);
   
@@ -115,7 +115,7 @@ export function ProtoContextProvider({ children }: { children: React.ReactNode }
         // Make sure only one listener is registered for one certificate
         // To prevent multiple listeners for the same certificate 
         // that can be executed once the certificate is uploaded
-        removeUploadedListener(proto, currentListener);
+        removeUploadedListener(currentListener, proto);
       }
     }
 
@@ -128,7 +128,7 @@ export function ProtoContextProvider({ children }: { children: React.ReactNode }
     return handlerId;
   }
 
-  function removeUploadedListener(protoInfo: ProtoInfo | undefined, handlerId: string) {
+  function removeUploadedListener(handlerId: string, protoInfo?: ProtoInfo) {
     removeEventListener(ProtoUploadAction.SUCCESS, handlerId);
     if (protoInfo) {
       setCurrentUploadedListener(protoInfo);

--- a/src/components/App/ProtoProvider.tsx
+++ b/src/components/App/ProtoProvider.tsx
@@ -8,8 +8,8 @@ export type ProtoContextType = {
   protos: ProtoFile[];
   setProtos: (props: ProtoFile[]) => void;
   handleProtoResult: (res: UploadProtoResponse, successEmit?: boolean) => void;
-  addUploadedListener: (protoInfo: ProtoInfo, handler: (protos: ProtoFile[]) => void) => string;
-  removeUploadedListener: (protoInfo: ProtoInfo, handlerId: string) => void;
+  addUploadedListener: (protoInfo: ProtoInfo | undefined, handler: (protos: ProtoFile[]) => void) => string;
+  removeUploadedListener: (protoInfo: ProtoInfo | undefined, handlerId: string) => void;
   handleMissingImport: () => void;
   toggleModalMissingImports: () => void;
   modalMissingImportsOpen: boolean;
@@ -107,24 +107,32 @@ export function ProtoContextProvider({ children }: { children: React.ReactNode }
   }
 
 
-  const addUploadedListener = (proto: ProtoInfo, handler: EventHandler) => {
-    const currentListener = getCurrentUploadedListener(proto);
-
-    if (currentListener) {
-      // Make sure only one listener is registered for one certificate
-      // To prevent multiple listeners for the same certificate 
-      // that can be executed once the certificate is uploaded
-      removeUploadedListener(proto, currentListener);
+  const addUploadedListener = (proto: ProtoInfo | undefined, handler: EventHandler) => {
+    if (proto) {
+      const currentListener = getCurrentUploadedListener(proto);
+  
+      if (currentListener) {
+        // Make sure only one listener is registered for one certificate
+        // To prevent multiple listeners for the same certificate 
+        // that can be executed once the certificate is uploaded
+        removeUploadedListener(proto, currentListener);
+      }
     }
 
     const handlerId = addEventListener(ProtoUploadAction.SUCCESS, handler);
-    setCurrentUploadedListener(proto, handlerId)
+
+    if (proto) {
+      setCurrentUploadedListener(proto, handlerId)
+    }
+
     return handlerId;
   }
 
-  function removeUploadedListener(protoInfo: ProtoInfo, handlerId: string) {
+  function removeUploadedListener(protoInfo: ProtoInfo | undefined, handlerId: string) {
     removeEventListener(ProtoUploadAction.SUCCESS, handlerId);
-    setCurrentUploadedListener(protoInfo);
+    if (protoInfo) {
+      setCurrentUploadedListener(protoInfo);
+    }
   }
 
   function getCurrentUploadedListener(protoInfo: ProtoInfo) {

--- a/src/components/App/ProtoProvider.tsx
+++ b/src/components/App/ProtoProvider.tsx
@@ -87,7 +87,7 @@ export function ProtoContextProvider({ children }: { children: React.ReactNode }
         if (res.protos) {
           onProtoUpload(res.protos);
 
-          if (successEmit) {
+          if (successEmit && !missingImports.current.length) {
             protoUploadEmit(ProtoUploadAction.SUCCESS, res.protos);
           }
         }

--- a/src/components/App/app.css
+++ b/src/components/App/app.css
@@ -214,3 +214,7 @@ a:hover {
   padding: calc(1em + 1ex);
   right: 0;
 }
+
+.table-tls a {
+  color: #1890ff;
+}

--- a/src/storage/Store.ts
+++ b/src/storage/Store.ts
@@ -16,7 +16,7 @@ export class Store {
     this.name = options.name;
   }
 
-  get(key: string, defaultValue: any = null, emptyCheck?: (val: any) => boolean): any {
+  get<T = any>(key: string, defaultValue: T | null = null, emptyCheck?: (val: T | null) => boolean): T {
     const raw = localStorage.getItem(this.createJoinedKey(key));
     
     let actualVal = defaultValue;
@@ -25,7 +25,7 @@ export class Store {
       try {
         actualVal = JSON.parse(raw);
       } catch (err) {
-        actualVal = raw;
+        // ignore
       }
     }
 
@@ -35,10 +35,10 @@ export class Store {
       }
     }
 
-    return actualVal;
+    return actualVal as T;
   }
 
-  set = (key: string, value: any) => {
+  set = <T = any>(key: string, value: T) => {
     this.keys.push(key);
     localStorage.setItem(this.createJoinedKey(key), JSON.stringify(value));
   }

--- a/src/storage/Store.ts
+++ b/src/storage/Store.ts
@@ -16,18 +16,26 @@ export class Store {
     this.name = options.name;
   }
 
-  get(key: string, defaultValue: any = null): any {
+  get(key: string, defaultValue: any = null, emptyCheck?: (val: any) => boolean): any {
     const raw = localStorage.getItem(this.createJoinedKey(key));
     
+    let actualVal = defaultValue;
+
     if (raw !== null) {
       try {
-        return JSON.parse(raw);
+        actualVal = JSON.parse(raw);
       } catch (err) {
-        return raw;
+        actualVal = raw;
       }
     }
 
-    return defaultValue;
+    if (emptyCheck && typeof emptyCheck === 'function') {
+      if (emptyCheck(actualVal)) {
+        actualVal = defaultValue;
+      }
+    }
+
+    return actualVal;
   }
 
   set = (key: string, value: any) => {

--- a/src/storage/tls.ts
+++ b/src/storage/tls.ts
@@ -15,12 +15,21 @@ export function storeTLSList(certs: Certificate[]) {
   TLSStore.set(TLS_KEYS.CERTIFICATES, certs);
 }
 
+function checkEmptyTLSList(val: any) {
+  return val === null || val === undefined || (val as []).length === 0;
+}
+
 export function getTLSList() {
-  const serverCertificate = {
+  const serverCertificate: Certificate = {
     useServerCertificate: true,
-    rootCert: { fileName: "Server Certificate", filePath: "" },
+    rootCert: {
+      fileName: "Server Certificate",
+      filePath: "",
+      type: 'rootCert',
+    },
   };
-  return TLSStore.get(TLS_KEYS.CERTIFICATES, [serverCertificate]);
+
+  return TLSStore.get(TLS_KEYS.CERTIFICATES, [serverCertificate], checkEmptyTLSList);
 }
 
 export function clearTLS() {

--- a/src/storage/tls.ts
+++ b/src/storage/tls.ts
@@ -1,15 +1,14 @@
 import { Certificate } from "../api";
+import { serverCertificate } from "../utils/certificates";
 import { Store } from "./Store";
 
 const TLSStore = new Store({
   name: "tls",
 });
 
-
 const TLS_KEYS = {
   CERTIFICATES: 'certificates'
 };
-
 
 export function storeTLSList(certs: Certificate[]) {
   TLSStore.set(TLS_KEYS.CERTIFICATES, certs);
@@ -20,15 +19,6 @@ function checkEmptyTLSList(val: any) {
 }
 
 export function getTLSList() {
-  const serverCertificate: Certificate = {
-    useServerCertificate: true,
-    rootCert: {
-      fileName: "Server Certificate",
-      filePath: "",
-      type: 'rootCert',
-    },
-  };
-
   return TLSStore.get(TLS_KEYS.CERTIFICATES, [serverCertificate], checkEmptyTLSList);
 }
 

--- a/src/utils/certificates.ts
+++ b/src/utils/certificates.ts
@@ -19,3 +19,32 @@ export function isSameCertificate(cert1?: Certificate, cert2?: Certificate) {
 
   return cert1?.rootCert?.filePath === cert2?.rootCert?.filePath;
 }
+
+
+/**
+ * @see https://www.ssls.com/knowledgebase/what-are-certificate-formats-and-what-is-the-difference-between-them/
+ */
+export const wellKnownCertExtensions = [
+  // Base64 (ASCII)
+  // PEM
+  '.pem',
+  '.crt',
+  '.ca-bundle',
+  // PKCS#7
+  '.p7b',
+  '.p7s',
+
+  // Binary
+  // DER
+  '.der',
+  '.cer',
+  // PKCS#12
+  '.pfx',
+  '.p12',
+];
+
+export const wellKnownPKFileExtensions = [
+  '.pem',
+  '.key',
+  '.pkcs12'
+];

--- a/src/utils/certificates.ts
+++ b/src/utils/certificates.ts
@@ -1,0 +1,21 @@
+import { Certificate } from "../api";
+
+// Default Server certificate
+export const serverCertificate: Certificate = {
+  useServerCertificate: true,
+  rootCert: {
+    fileName: "Server Certificate",
+    filePath: "",
+    type: 'rootCert',
+  },
+};
+
+export function isSameCertificate(cert1?: Certificate, cert2?: Certificate) {
+  if (typeof cert1 !== typeof cert2) return false;
+
+  if (!(cert1 && cert2)) {
+    return false;
+  }
+
+  return cert1?.rootCert?.filePath === cert2?.rootCert?.filePath;
+}

--- a/src/utils/useEventEmitter.ts
+++ b/src/utils/useEventEmitter.ts
@@ -9,7 +9,7 @@ export default function useEventEmitter(baseName = 'default') {
   const { current: emitter } = useRef<EventEmitter>(new EventEmitter());
   const { current: handlerMap } = useRef<Map<string, EventHandler>>(new Map());
 
-  const getHandlers = (handlerId: string) => handlerMap.get(handlerId);
+  const getHandler = (handlerId: string) => handlerMap.get(handlerId);
 
   const setHandler = (handler: EventHandler) => {
     const handlerId = uuid();
@@ -25,7 +25,7 @@ export default function useEventEmitter(baseName = 'default') {
   }
 
   const removeEventListener = (eventName: string, handlerId: string) => {
-    const handler = getHandlers(handlerId);
+    const handler = getHandler(handlerId);
     if (!handler) return;
 
     emitter.off(`${baseName}:${eventName}`, handler);


### PR DESCRIPTION
resolve https://github.com/zalopay-oss/backstage-grpc-playground/issues/1

- User now can upload TLS certificate
- Add new config: grpcPlayground.certStore.enabled
- Handle stateful requests (certificate will be kept sending along)
- Handle sidecases:
  - Missing certificate files: if for any reason that some files
of a certificate are missing, a modal will show up for user
to re-upload those files back. And if uploaded files are suitable,
the request will be continued.