### PR TITLE
Release v0.3.0-next.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [v0.3.0-next.0](https://github.com/zalopay-oss/backstage-grpc-playground/tree/v0.3.0-next.0) (2022-08-29)
+
+[Full Changelog](https://github.com/zalopay-oss/backstage-grpc-playground/compare/v0.2.0-next.0...v0.3.0-next.0)
+
+**Implemented features:**
+
+- Support proto library [\#9](https://github.com/zalopay-oss/backstage-grpc-playground/issues/9)
+
+## [v0.2.0-next.0](https://github.com/zalopay-oss/backstage-grpc-playground/tree/v0.2.0-next.0) (2022-08-04)
+
+**Implemented enhancements:**
+
+- Support SSL [\#1](https://github.com/zalopay-oss/backstage-grpc-playground/issues/1)
+
+[Full Changelog](https://github.com/zalopay-oss/backstage-grpc-playground/compare/v0.1.3b...v0.2.0-next.0)
+
+## [v0.1.3b](https://github.com/zalopay-oss/backstage-grpc-playground/tree/v0.1.3b) (2022-07-19)
+
+[Full Changelog](https://github.com/zalopay-oss/backstage-grpc-playground/compare/v0.1.3...v0.1.3b)
+
 ## [v0.1.3](https://github.com/zalopay-oss/backstage-grpc-playground/tree/v0.1.3) (2022-07-15)
 
 [Full Changelog](https://github.com/zalopay-oss/backstage-grpc-playground/compare/v0.1.2...v0.1.3)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ View [Full changelog](CHANGELOG.md)
 
 ## Requirements
 
-- Backstage ^1.1.0
+- Backstage ^1.5.0
 - Node.JS 14 | 16
 
 ## Methods supported

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ View [Full changelog](CHANGELOG.md)
 
 We are currently not supporting
 
-- SSL call [See issue](https://github.com/zalopay-oss/backstage-grpc-playground/issues/1)
 - Load proto from reflection. [See issue](https://github.com/zalopay-oss/backstage-grpc-playground/issues/2)
 
 ## Install
@@ -131,6 +130,8 @@ Example importing API definition from Github [examples/yaml-definition/unary.yam
 
   - User upload a file "account.proto" that imports some google-apis proto files. In this case user should import google folder
   ![missing import 2](examples/images/missing_import_2.gif)
+- Support generating document file in https://github.com/zalopay-oss/backstage-grpc-playground-backend/pull/1
+- Support proto library https://github.com/zalopay-oss/backstage-grpc-playground/issues/9, see [guide](examples/yaml-definition/libraries.yaml)
 
 ## Yaml file definition
 

--- a/examples/libraries/google-apis/default/google/README.md
+++ b/examples/libraries/google-apis/default/google/README.md
@@ -1,0 +1,7 @@
+This folder contains common proto files.
+We dont exclude these files from git
+
+Collected from 
+- https://github.com/bloomrpc/bloomrpc/tree/master/static/google
+- https://github.com/googleapis/api-common-protos/tree/main/google/api
+- https://github.com/protocolbuffers/protobuf/tree/v21.5/src/google/protobuf

--- a/examples/libraries/google-apis/default/google/api/annotations.proto
+++ b/examples/libraries/google-apis/default/google/api/annotations.proto
@@ -1,0 +1,31 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/api/http.proto";
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "AnnotationsProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.MethodOptions {
+  // See `HttpRule`.
+  HttpRule http = 72295728;
+}

--- a/examples/libraries/google-apis/default/google/api/http.proto
+++ b/examples/libraries/google-apis/default/google/api/http.proto
@@ -1,0 +1,375 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "HttpProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+// Defines the HTTP configuration for an API service. It contains a list of
+// [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+// to one or more HTTP REST API methods.
+message Http {
+  // A list of HTTP configuration rules that apply to individual API methods.
+  //
+  // **NOTE:** All service configuration rules follow "last one wins" order.
+  repeated HttpRule rules = 1;
+
+  // When set to true, URL path parameters will be fully URI-decoded except in
+  // cases of single segment matches in reserved expansion, where "%2F" will be
+  // left encoded.
+  //
+  // The default behavior is to not decode RFC 6570 reserved characters in multi
+  // segment matches.
+  bool fully_decode_reserved_expansion = 2;
+}
+
+// # gRPC Transcoding
+//
+// gRPC Transcoding is a feature for mapping between a gRPC method and one or
+// more HTTP REST endpoints. It allows developers to build a single API service
+// that supports both gRPC APIs and REST APIs. Many systems, including [Google
+// APIs](https://github.com/googleapis/googleapis),
+// [Cloud Endpoints](https://cloud.google.com/endpoints), [gRPC
+// Gateway](https://github.com/grpc-ecosystem/grpc-gateway),
+// and [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature
+// and use it for large scale production services.
+//
+// `HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies
+// how different portions of the gRPC request message are mapped to the URL
+// path, URL query parameters, and HTTP request body. It also controls how the
+// gRPC response message is mapped to the HTTP response body. `HttpRule` is
+// typically specified as an `google.api.http` annotation on the gRPC method.
+//
+// Each mapping specifies a URL path template and an HTTP method. The path
+// template may refer to one or more fields in the gRPC request message, as long
+// as each field is a non-repeated field with a primitive (non-message) type.
+// The path template controls how fields of the request message are mapped to
+// the URL path.
+//
+// Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get: "/v1/{name=messages/*}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string name = 1; // Mapped to URL path.
+//     }
+//     message Message {
+//       string text = 1; // The resource content.
+//     }
+//
+// This enables an HTTP REST to gRPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456`  | `GetMessage(name: "messages/123456")`
+//
+// Any fields in the request message which are not bound by the path template
+// automatically become HTTP query parameters if there is no HTTP request body.
+// For example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get:"/v1/messages/{message_id}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       message SubMessage {
+//         string subfield = 1;
+//       }
+//       string message_id = 1; // Mapped to URL path.
+//       int64 revision = 2;    // Mapped to URL query parameter `revision`.
+//       SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+//     }
+//
+// This enables a HTTP JSON to RPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
+// `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield:
+// "foo"))`
+//
+// Note that fields which are mapped to URL query parameters must have a
+// primitive type or a repeated primitive type or a non-repeated message type.
+// In the case of a repeated type, the parameter can be repeated in the URL
+// as `...?param=A&param=B`. In the case of a message type, each field of the
+// message is mapped to a separate parameter, such as
+// `...?foo.a=A&foo.b=B&foo.c=C`.
+//
+// For HTTP methods that allow a request body, the `body` field
+// specifies the mapping. Consider a REST update method on the
+// message resource collection:
+//
+//     service Messaging {
+//       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "message"
+//         };
+//       }
+//     }
+//     message UpdateMessageRequest {
+//       string message_id = 1; // mapped to the URL
+//       Message message = 2;   // mapped to the body
+//     }
+//
+// The following HTTP JSON to RPC mapping is enabled, where the
+// representation of the JSON in the request body is determined by
+// protos JSON encoding:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" message { text: "Hi!" })`
+//
+// The special name `*` can be used in the body mapping to define that
+// every field not bound by the path template should be mapped to the
+// request body.  This enables the following alternative definition of
+// the update method:
+//
+//     service Messaging {
+//       rpc UpdateMessage(Message) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "*"
+//         };
+//       }
+//     }
+//     message Message {
+//       string message_id = 1;
+//       string text = 2;
+//     }
+//
+//
+// The following HTTP JSON to RPC mapping is enabled:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" text: "Hi!")`
+//
+// Note that when using `*` in the body mapping, it is not possible to
+// have HTTP parameters, as all fields not bound by the path end in
+// the body. This makes this option more rarely used in practice when
+// defining REST APIs. The common usage of `*` is in custom methods
+// which don't use the URL at all for transferring data.
+//
+// It is possible to define multiple HTTP methods for one RPC by using
+// the `additional_bindings` option. Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           get: "/v1/messages/{message_id}"
+//           additional_bindings {
+//             get: "/v1/users/{user_id}/messages/{message_id}"
+//           }
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string message_id = 1;
+//       string user_id = 2;
+//     }
+//
+// This enables the following two alternative HTTP JSON to RPC mappings:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
+// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id:
+// "123456")`
+//
+// ## Rules for HTTP mapping
+//
+// 1. Leaf request fields (recursive expansion nested messages in the request
+//    message) are classified into three categories:
+//    - Fields referred by the path template. They are passed via the URL path.
+//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+//      request body.
+//    - All other fields are passed via the URL query parameters, and the
+//      parameter name is the field path in the request message. A repeated
+//      field can be represented as multiple query parameters under the same
+//      name.
+//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+//     are passed via URL path and HTTP request body.
+//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+//     fields are passed via URL path and URL query parameters.
+//
+// ### Path template syntax
+//
+//     Template = "/" Segments [ Verb ] ;
+//     Segments = Segment { "/" Segment } ;
+//     Segment  = "*" | "**" | LITERAL | Variable ;
+//     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+//     FieldPath = IDENT { "." IDENT } ;
+//     Verb     = ":" LITERAL ;
+//
+// The syntax `*` matches a single URL path segment. The syntax `**` matches
+// zero or more URL path segments, which must be the last part of the URL path
+// except the `Verb`.
+//
+// The syntax `Variable` matches part of the URL path as specified by its
+// template. A variable template must not contain other variables. If a variable
+// matches a single path segment, its template may be omitted, e.g. `{var}`
+// is equivalent to `{var=*}`.
+//
+// The syntax `LITERAL` matches literal text in the URL path. If the `LITERAL`
+// contains any reserved character, such characters should be percent-encoded
+// before the matching.
+//
+// If a variable contains exactly one path segment, such as `"{var}"` or
+// `"{var=*}"`, when such a variable is expanded into a URL path on the client
+// side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The
+// server side does the reverse decoding. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{var}`.
+//
+// If a variable contains multiple path segments, such as `"{var=foo/*}"`
+// or `"{var=**}"`, when such a variable is expanded into a URL path on the
+// client side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.
+// The server side does the reverse decoding, except "%2F" and "%2f" are left
+// unchanged. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{+var}`.
+//
+// ## Using gRPC API Service Configuration
+//
+// gRPC API Service Configuration (service config) is a configuration language
+// for configuring a gRPC service to become a user-facing product. The
+// service config is simply the YAML representation of the `google.api.Service`
+// proto message.
+//
+// As an alternative to annotating your proto file, you can configure gRPC
+// transcoding in your service config YAML files. You do this by specifying a
+// `HttpRule` that maps the gRPC method to a REST endpoint, achieving the same
+// effect as the proto annotation. This can be particularly useful if you
+// have a proto that is reused in multiple services. Note that any transcoding
+// specified in the service config will override any matching transcoding
+// configuration in the proto.
+//
+// Example:
+//
+//     http:
+//       rules:
+//         # Selects a gRPC method and applies HttpRule to it.
+//         - selector: example.v1.Messaging.GetMessage
+//           get: /v1/messages/{message_id}/{sub.subfield}
+//
+// ## Special notes
+//
+// When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
+// proto to JSON conversion must follow the [proto3
+// specification](https://developers.google.com/protocol-buffers/docs/proto3#json).
+//
+// While the single segment variable follows the semantics of
+// [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String
+// Expansion, the multi segment variable **does not** follow RFC 6570 Section
+// 3.2.3 Reserved Expansion. The reason is that the Reserved Expansion
+// does not expand special characters like `?` and `#`, which would lead
+// to invalid URLs. As the result, gRPC Transcoding uses a custom encoding
+// for multi segment variables.
+//
+// The path variables **must not** refer to any repeated or mapped field,
+// because client libraries are not capable of handling such variable expansion.
+//
+// The path variables **must not** capture the leading "/" character. The reason
+// is that the most common use case "{var}" does not capture the leading "/"
+// character. For consistency, all path variables must share the same behavior.
+//
+// Repeated message fields must not be mapped to URL query parameters, because
+// no client library can support such complicated mapping.
+//
+// If an API needs to use a JSON array for request or response body, it can map
+// the request or response body to a repeated field. However, some gRPC
+// Transcoding implementations may not support this feature.
+message HttpRule {
+  // Selects a method to which this rule applies.
+  //
+  // Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+  string selector = 1;
+
+  // Determines the URL pattern is matched by this rules. This pattern can be
+  // used with any of the {get|put|post|delete|patch} methods. A custom method
+  // can be defined using the 'custom' field.
+  oneof pattern {
+    // Maps to HTTP GET. Used for listing and getting information about
+    // resources.
+    string get = 2;
+
+    // Maps to HTTP PUT. Used for replacing a resource.
+    string put = 3;
+
+    // Maps to HTTP POST. Used for creating a resource or performing an action.
+    string post = 4;
+
+    // Maps to HTTP DELETE. Used for deleting a resource.
+    string delete = 5;
+
+    // Maps to HTTP PATCH. Used for updating a resource.
+    string patch = 6;
+
+    // The custom pattern is used for specifying an HTTP method that is not
+    // included in the `pattern` field, such as HEAD, or "*" to leave the
+    // HTTP method unspecified for this rule. The wild-card rule is useful
+    // for services that provide content to Web (HTML) clients.
+    CustomHttpPattern custom = 8;
+  }
+
+  // The name of the request field whose value is mapped to the HTTP request
+  // body, or `*` for mapping all request fields not captured by the path
+  // pattern to the HTTP body, or omitted for not having any HTTP request body.
+  //
+  // NOTE: the referred field must be present at the top-level of the request
+  // message type.
+  string body = 7;
+
+  // Optional. The name of the response field whose value is mapped to the HTTP
+  // response body. When omitted, the entire response message will be used
+  // as the HTTP response body.
+  //
+  // NOTE: The referred field must be present at the top-level of the response
+  // message type.
+  string response_body = 12;
+
+  // Additional HTTP bindings for the selector. Nested bindings must
+  // not contain an `additional_bindings` field themselves (that is,
+  // the nesting may only be one level deep).
+  repeated HttpRule additional_bindings = 11;
+}
+
+// A custom pattern is used for defining custom HTTP verb.
+message CustomHttpPattern {
+  // The name of this custom HTTP verb.
+  string kind = 1;
+
+  // The path matched by this custom verb.
+  string path = 2;
+}

--- a/examples/libraries/google-apis/default/google/protobuf/api.proto
+++ b/examples/libraries/google-apis/default/google/protobuf/api.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package google.protobuf;
+
+import "google/protobuf/source_context.proto";
+import "google/protobuf/type.proto";
+
+message Api {
+
+    string name = 1;
+    repeated Method methods = 2;
+    repeated Option options = 3;
+    string version = 4;
+    SourceContext source_context = 5;
+    repeated Mixin mixins = 6;
+    Syntax syntax = 7;
+}
+
+message Method {
+
+    string name = 1;
+    string request_type_url = 2;
+    bool request_streaming = 3;
+    string response_type_url = 4;
+    bool response_streaming = 5;
+    repeated Option options = 6;
+    Syntax syntax = 7;
+}
+
+message Mixin {
+
+    string name = 1;
+    string root = 2;
+}

--- a/examples/libraries/google-apis/default/google/protobuf/descriptor.proto
+++ b/examples/libraries/google-apis/default/google/protobuf/descriptor.proto
@@ -1,0 +1,286 @@
+syntax = "proto2";
+
+package google.protobuf;
+
+message FileDescriptorSet {
+
+    repeated FileDescriptorProto file = 1;
+}
+
+message FileDescriptorProto {
+
+    optional string name = 1;
+    optional string package = 2;
+    repeated string dependency = 3;
+    repeated int32 public_dependency = 10;
+    repeated int32 weak_dependency = 11;
+    repeated DescriptorProto message_type = 4;
+    repeated EnumDescriptorProto enum_type = 5;
+    repeated ServiceDescriptorProto service = 6;
+    repeated FieldDescriptorProto extension = 7;
+    optional FileOptions options = 8;
+    optional SourceCodeInfo source_code_info = 9;
+    optional string syntax = 12;
+}
+
+message DescriptorProto {
+
+    optional string name = 1;
+    repeated FieldDescriptorProto field = 2;
+    repeated FieldDescriptorProto extension = 6;
+    repeated DescriptorProto nested_type = 3;
+    repeated EnumDescriptorProto enum_type = 4;
+    repeated ExtensionRange extension_range = 5;
+    repeated OneofDescriptorProto oneof_decl = 8;
+    optional MessageOptions options = 7;
+    repeated ReservedRange reserved_range = 9;
+    repeated string reserved_name = 10;
+
+    message ExtensionRange {
+
+        optional int32 start = 1;
+        optional int32 end = 2;
+    }
+
+    message ReservedRange {
+
+        optional int32 start = 1;
+        optional int32 end = 2;
+    }
+}
+
+message FieldDescriptorProto {
+
+    optional string name = 1;
+    optional int32 number = 3;
+    optional Label label = 4;
+    optional Type type = 5;
+    optional string type_name = 6;
+    optional string extendee = 2;
+    optional string default_value = 7;
+    optional int32 oneof_index = 9;
+    optional string json_name = 10;
+    optional FieldOptions options = 8;
+
+    enum Type {
+
+        TYPE_DOUBLE = 1;
+        TYPE_FLOAT = 2;
+        TYPE_INT64 = 3;
+        TYPE_UINT64 = 4;
+        TYPE_INT32 = 5;
+        TYPE_FIXED64 = 6;
+        TYPE_FIXED32 = 7;
+        TYPE_BOOL = 8;
+        TYPE_STRING = 9;
+        TYPE_GROUP = 10;
+        TYPE_MESSAGE = 11;
+        TYPE_BYTES = 12;
+        TYPE_UINT32 = 13;
+        TYPE_ENUM = 14;
+        TYPE_SFIXED32 = 15;
+        TYPE_SFIXED64 = 16;
+        TYPE_SINT32 = 17;
+        TYPE_SINT64 = 18;
+    }
+
+    enum Label {
+
+        LABEL_OPTIONAL = 1;
+        LABEL_REQUIRED = 2;
+        LABEL_REPEATED = 3;
+    }
+}
+
+message OneofDescriptorProto {
+
+    optional string name = 1;
+    optional OneofOptions options = 2;
+}
+
+message EnumDescriptorProto {
+
+    optional string name = 1;
+    repeated EnumValueDescriptorProto value = 2;
+    optional EnumOptions options = 3;
+}
+
+message EnumValueDescriptorProto {
+
+    optional string name = 1;
+    optional int32 number = 2;
+    optional EnumValueOptions options = 3;
+}
+
+message ServiceDescriptorProto {
+
+    optional string name = 1;
+    repeated MethodDescriptorProto method = 2;
+    optional ServiceOptions options = 3;
+}
+
+message MethodDescriptorProto {
+
+    optional string name = 1;
+    optional string input_type = 2;
+    optional string output_type = 3;
+    optional MethodOptions options = 4;
+    optional bool client_streaming = 5;
+    optional bool server_streaming = 6;
+}
+
+message FileOptions {
+
+    optional string java_package = 1;
+    optional string java_outer_classname = 8;
+    optional bool java_multiple_files = 10;
+    optional bool java_generate_equals_and_hash = 20 [deprecated=true];
+    optional bool java_string_check_utf8 = 27;
+    optional OptimizeMode optimize_for = 9 [default=SPEED];
+    optional string go_package = 11;
+    optional bool cc_generic_services = 16;
+    optional bool java_generic_services = 17;
+    optional bool py_generic_services = 18;
+    optional bool deprecated = 23;
+    optional bool cc_enable_arenas = 31;
+    optional string objc_class_prefix = 36;
+    optional string csharp_namespace = 37;
+    repeated UninterpretedOption uninterpreted_option = 999;
+
+    enum OptimizeMode {
+
+        SPEED = 1;
+        CODE_SIZE = 2;
+        LITE_RUNTIME = 3;
+    }
+
+    extensions 1000 to max;
+
+    reserved 38;
+}
+
+message MessageOptions {
+
+    optional bool message_set_wire_format = 1;
+    optional bool no_standard_descriptor_accessor = 2;
+    optional bool deprecated = 3;
+    optional bool map_entry = 7;
+    repeated UninterpretedOption uninterpreted_option = 999;
+
+    extensions 1000 to max;
+
+    reserved 8;
+}
+
+message FieldOptions {
+
+    optional CType ctype = 1 [default=STRING];
+    optional bool packed = 2;
+    optional JSType jstype = 6 [default=JS_NORMAL];
+    optional bool lazy = 5;
+    optional bool deprecated = 3;
+    optional bool weak = 10;
+    repeated UninterpretedOption uninterpreted_option = 999;
+
+    enum CType {
+
+        STRING = 0;
+        CORD = 1;
+        STRING_PIECE = 2;
+    }
+
+    enum JSType {
+
+        JS_NORMAL = 0;
+        JS_STRING = 1;
+        JS_NUMBER = 2;
+    }
+
+    extensions 1000 to max;
+
+    reserved 4;
+}
+
+message OneofOptions {
+
+    repeated UninterpretedOption uninterpreted_option = 999;
+
+    extensions 1000 to max;
+}
+
+message EnumOptions {
+
+    optional bool allow_alias = 2;
+    optional bool deprecated = 3;
+    repeated UninterpretedOption uninterpreted_option = 999;
+
+    extensions 1000 to max;
+}
+
+message EnumValueOptions {
+
+    optional bool deprecated = 1;
+    repeated UninterpretedOption uninterpreted_option = 999;
+
+    extensions 1000 to max;
+}
+
+message ServiceOptions {
+
+    optional bool deprecated = 33;
+    repeated UninterpretedOption uninterpreted_option = 999;
+
+    extensions 1000 to max;
+}
+
+message MethodOptions {
+
+    optional bool deprecated = 33;
+    repeated UninterpretedOption uninterpreted_option = 999;
+
+    extensions 1000 to max;
+}
+
+message UninterpretedOption {
+
+    repeated NamePart name = 2;
+    optional string identifier_value = 3;
+    optional uint64 positive_int_value = 4;
+    optional int64 negative_int_value = 5;
+    optional double double_value = 6;
+    optional bytes string_value = 7;
+    optional string aggregate_value = 8;
+
+    message NamePart {
+
+        required string name_part = 1;
+        required bool is_extension = 2;
+    }
+}
+
+message SourceCodeInfo {
+
+    repeated Location location = 1;
+
+    message Location {
+
+        repeated int32 path = 1 [packed=true];
+        repeated int32 span = 2 [packed=true];
+        optional string leading_comments = 3;
+        optional string trailing_comments = 4;
+        repeated string leading_detached_comments = 6;
+    }
+}
+
+message GeneratedCodeInfo {
+
+    repeated Annotation annotation = 1;
+
+    message Annotation {
+
+        repeated int32 path = 1 [packed=true];
+        optional string source_file = 2;
+        optional int32 begin = 3;
+        optional int32 end = 4;
+    }
+}

--- a/examples/libraries/google-apis/default/google/protobuf/source_context.proto
+++ b/examples/libraries/google-apis/default/google/protobuf/source_context.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package google.protobuf;
+
+message SourceContext {
+    string file_name = 1;
+}

--- a/examples/libraries/google-apis/default/google/protobuf/struct.proto
+++ b/examples/libraries/google-apis/default/google/protobuf/struct.proto
@@ -1,0 +1,95 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
+option go_package = "github.com/golang/protobuf/ptypes/struct;structpb";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "StructProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+
+// `Struct` represents a structured data value, consisting of fields
+// which map to dynamically typed values. In some languages, `Struct`
+// might be supported by a native representation. For example, in
+// scripting languages like JS a struct is represented as an
+// object. The details of that representation are described together
+// with the proto support for the language.
+//
+// The JSON representation for `Struct` is JSON object.
+message Struct {
+    // Unordered map of dynamically typed values.
+    map<string, Value> fields = 1;
+}
+
+// `Value` represents a dynamically typed value which can be either
+// null, a number, a string, a boolean, a recursive struct value, or a
+// list of values. A producer of value is expected to set one of that
+// variants, absence of any variant indicates an error.
+//
+// The JSON representation for `Value` is JSON value.
+message Value {
+    // The kind of value.
+    oneof kind {
+        // Represents a null value.
+        NullValue null_value = 1;
+        // Represents a double value.
+        double number_value = 2;
+        // Represents a string value.
+        string string_value = 3;
+        // Represents a boolean value.
+        bool bool_value = 4;
+        // Represents a structured value.
+        Struct struct_value = 5;
+        // Represents a repeated `Value`.
+        ListValue list_value = 6;
+    }
+}
+
+// `NullValue` is a singleton enumeration to represent the null value for the
+// `Value` type union.
+//
+//  The JSON representation for `NullValue` is JSON `null`.
+enum NullValue {
+    // Null value.
+    NULL_VALUE = 0;
+}
+
+// `ListValue` is a wrapper around a repeated field of values.
+//
+// The JSON representation for `ListValue` is JSON array.
+message ListValue {
+    // Repeated field of dynamically typed values.
+    repeated Value values = 1;
+}

--- a/examples/libraries/google-apis/default/google/protobuf/type.proto
+++ b/examples/libraries/google-apis/default/google/protobuf/type.proto
@@ -1,0 +1,89 @@
+syntax = "proto3";
+
+package google.protobuf;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/source_context.proto";
+
+message Type {
+
+    string name = 1;
+    repeated Field fields = 2;
+    repeated string oneofs = 3;
+    repeated Option options = 4;
+    SourceContext source_context = 5;
+    Syntax syntax = 6;
+}
+
+message Field {
+
+    Kind kind = 1;
+    Cardinality cardinality = 2;
+    int32 number = 3;
+    string name = 4;
+    string type_url = 6;
+    int32 oneof_index = 7;
+    bool packed = 8;
+    repeated Option options = 9;
+    string json_name = 10;
+    string default_value = 11;
+
+    enum Kind {
+
+        TYPE_UNKNOWN = 0;
+        TYPE_DOUBLE = 1;
+        TYPE_FLOAT = 2;
+        TYPE_INT64 = 3;
+        TYPE_UINT64 = 4;
+        TYPE_INT32 = 5;
+        TYPE_FIXED64 = 6;
+        TYPE_FIXED32 = 7;
+        TYPE_BOOL = 8;
+        TYPE_STRING = 9;
+        TYPE_GROUP = 10;
+        TYPE_MESSAGE = 11;
+        TYPE_BYTES = 12;
+        TYPE_UINT32 = 13;
+        TYPE_ENUM = 14;
+        TYPE_SFIXED32 = 15;
+        TYPE_SFIXED64 = 16;
+        TYPE_SINT32 = 17;
+        TYPE_SINT64 = 18;
+    }
+
+    enum Cardinality {
+
+        CARDINALITY_UNKNOWN = 0;
+        CARDINALITY_OPTIONAL = 1;
+        CARDINALITY_REQUIRED = 2;
+        CARDINALITY_REPEATED = 3;
+    }
+}
+
+message Enum {
+
+    string name = 1;
+    repeated EnumValue enumvalue = 2;
+    repeated Option options = 3;
+    SourceContext source_context = 4;
+    Syntax syntax = 5;
+}
+
+message EnumValue {
+
+    string name = 1;
+    int32 number = 2;
+    repeated Option options = 3;
+}
+
+message Option {
+
+    string name = 1;
+    Any value = 2;
+}
+
+enum Syntax {
+
+    SYNTAX_PROTO2 = 0;
+    SYNTAX_PROTO3 = 1;
+}

--- a/examples/libraries/google-apis/default/google/rpc/status.proto
+++ b/examples/libraries/google-apis/default/google/rpc/status.proto
@@ -1,0 +1,92 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+import "google/protobuf/any.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
+option java_multiple_files = true;
+option java_outer_classname = "StatusProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+
+// The `Status` type defines a logical error model that is suitable for different
+// programming environments, including REST APIs and RPC APIs. It is used by
+// [gRPC](https://github.com/grpc). The error model is designed to be:
+//
+// - Simple to use and understand for most users
+// - Flexible enough to meet unexpected needs
+//
+// # Overview
+//
+// The `Status` message contains three pieces of data: error code, error message,
+// and error details. The error code should be an enum value of
+// [google.rpc.Code][google.rpc.Code], but it may accept additional error codes if needed.  The
+// error message should be a developer-facing English message that helps
+// developers *understand* and *resolve* the error. If a localized user-facing
+// error message is needed, put the localized message in the error details or
+// localize it in the client. The optional error details may contain arbitrary
+// information about the error. There is a predefined set of error detail types
+// in the package `google.rpc` which can be used for common error conditions.
+//
+// # Language mapping
+//
+// The `Status` message is the logical representation of the error model, but it
+// is not necessarily the actual wire format. When the `Status` message is
+// exposed in different client libraries and different wire protocols, it can be
+// mapped differently. For example, it will likely be mapped to some exceptions
+// in Java, but more likely mapped to some error codes in C.
+//
+// # Other uses
+//
+// The error model and the `Status` message can be used in a variety of
+// environments, either with or without APIs, to provide a
+// consistent developer experience across different environments.
+//
+// Example uses of this error model include:
+//
+// - Partial errors. If a service needs to return partial errors to the client,
+//     it may embed the `Status` in the normal response to indicate the partial
+//     errors.
+//
+// - Workflow errors. A typical workflow has multiple steps. Each step may
+//     have a `Status` message for error reporting purpose.
+//
+// - Batch operations. If a client uses batch request and batch response, the
+//     `Status` message should be used directly inside batch response, one for
+//     each error sub-response.
+//
+// - Asynchronous operations. If an API call embeds asynchronous operation
+//     results in its response, the status of those operations should be
+//     represented directly using the `Status` message.
+//
+// - Logging. If some API errors are stored in logs, the message `Status` could
+//     be used directly after any stripping needed for security/privacy reasons.
+message Status {
+  // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+  int32 code = 1;
+
+  // A developer-facing error message, which should be in English. Any
+  // user-facing error message should be localized and sent in the
+  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+  string message = 2;
+
+  // A list of messages that carry the error details.  There will be a
+  // common set of message types for APIs to use.
+  repeated google.protobuf.Any details = 3;
+}

--- a/examples/yaml-definition/README.md
+++ b/examples/yaml-definition/README.md
@@ -14,3 +14,7 @@ Configuration explained:
   - file_name
   - url
   - file_path
+- libraries (array, optional): libraries that shared between above proto files
+  - name
+  - url (optional)
+  - path (optional)

--- a/examples/yaml-definition/libraries.yaml
+++ b/examples/yaml-definition/libraries.yaml
@@ -1,0 +1,24 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: helloworld-unary-api
+  description: helloworld unary gRPC
+  
+spec:
+  type: grpc
+  lifecycle: production
+  owner: zalopay-oss
+  definition:
+    $text: https://github.com/zalopay-oss/backstage-grpc-playground/blob/main/examples/unary/helloworld.proto
+  files:
+    - file_name: helloworld.proto
+      file_path: examples/unary/helloworld.proto
+      url: https://github.com/zalopay-oss/backstage-grpc-playground/blob/main/examples/unary/helloworld.proto
+  libraries: 
+    - name: google-apis
+      path: google
+      url: https://github.com/zalopay-oss/backstage-grpc-playground/blob/main/examples/libraries/google-apis
+  targets:
+    dev:
+      host: 0.0.0.0
+      port: 8084

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-grpc-playground",
-  "version": "0.2.0-next.0",
+  "version": "0.3.0-next.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
-    "@backstage/core-plugin-api": "^1.0.2",
-    "@backstage/integration-react": "^1.1.0",
-    "@backstage/plugin-catalog-react": "^1.1.0",
+    "@backstage/core-plugin-api": "^1.0.5",
+    "@backstage/integration-react": "^1.1.3",
+    "@backstage/plugin-catalog-react": "^1.1.3",
     "@microsoft/fetch-event-source": "^2.0.1",
     "antd": "^4.20.7",
     "brace": "^0.11.1",
@@ -66,13 +66,13 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.17.1",
-    "@backstage/core-app-api": "^1.0.2",
-    "@backstage/dev-utils": "^1.0.2",
-    "@backstage/test-utils": "^1.1.0",
+    "@backstage/cli": "^0.18.1",
+    "@backstage/core-app-api": "^1.0.5",
+    "@backstage/dev-utils": "^1.0.5",
+    "@backstage/test-utils": "^1.1.3",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",
-    "@testing-library/user-event": "^13.1.8",
+    "@testing-library/user-event": "^14.0.0",
     "@types/jest": "*",
     "@types/lodash.get": "^4.4.7",
     "@types/mousetrap": "^1.6.9",
@@ -80,7 +80,7 @@
     "@types/path-parse": "^1.0.19",
     "@types/uuid": "^8.3.4",
     "cross-fetch": "^3.1.5",
-    "msw": "^0.35.0"
+    "msw": "^0.44.0"
   },
   "files": [
     "dist",

--- a/src/api/GrpcPlaygroundApi.ts
+++ b/src/api/GrpcPlaygroundApi.ts
@@ -84,10 +84,17 @@ export interface SendServerRequest {
   (payload: SendRequestPayload, options?: GRPCPlaygroundRequestOptions): Promise<SendRequestResponse>
 }
 
+export interface GetProtoTextResponse {
+  status: LoadProtoStatus;
+  message?: string;
+  protoText?: string;
+}
+
 export interface GrpcPlaygroundApi {
   uploadProto: UploadProtoRequest;
   sendServerRequest: SendServerRequest;
   getProto: GetProtoRequest;
+  getProtoText: (protoPath: string) => Promise<GetProtoTextResponse>;
   setEntityName: (entity: string) => void;
   getCertificates: (options?: GRPCPlaygroundRequestOptions) => Promise<Certificate[]>;
   deleteCertificate: (certificateId: string, options?: GRPCPlaygroundRequestOptions) => Promise<DeleteCertificateResponse>;

--- a/src/api/GrpcPlaygroundApiClient.ts
+++ b/src/api/GrpcPlaygroundApiClient.ts
@@ -4,7 +4,8 @@ import { ScmAuthApi } from "@backstage/integration-react";
 import {
   GrpcPlaygroundApi, GRPCPlaygroundRequestOptions,
   GetProtoPayload, SendRequestPayload, SendRequestResponse,
-  UploadProtoPayload, UploadProtoResponse, UploadCertificatePayload, UploadCertificateResponse, DeleteCertificateResponse
+  UploadProtoPayload, UploadProtoResponse, UploadCertificatePayload, UploadCertificateResponse,
+  DeleteCertificateResponse, GetProtoTextResponse
 } from "./GrpcPlaygroundApi";
 import { Certificate } from "./types";
 
@@ -30,6 +31,26 @@ export class GrpcPlaygroundApiClient implements GrpcPlaygroundApi {
     this.fetchApi = options.fetchApi || { fetch: window.fetch.bind(window) };
     this.entityName = '';
   }
+
+  getProtoText = async (protoPath: string, options?: GRPCPlaygroundRequestOptions): Promise<GetProtoTextResponse> => {
+    const { token } = await this.identityApi.getCredentials();
+    const fetch = options?.fetcher || this.fetchApi.fetch;
+    const query = ['filePath', protoPath].join('=');
+
+    const res = await fetch(
+      `${await this.discoveryApi.getBaseUrl('grpc-playground')}/proto-text/${this.entityName}?${query}`,
+      {
+        ...(options?.fetchOptions || {}),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token && { Authorization: `Bearer ${token}` }),
+        },
+      },
+    );
+
+    const data = await res.json();
+    return data;
+  };
 
   setEntityName = (entityName: string) => {
     this.entityName = entityName;

--- a/src/api/protobuf.ts
+++ b/src/api/protobuf.ts
@@ -6,7 +6,6 @@ export interface Proto {
   fileName: string;
   filePath: string;
   imports?: PlaceholderFile[];
-  protoText: string;
   protoDoc: string;
   ast: GrpcObject;
   root: Root;
@@ -24,7 +23,6 @@ export type ServiceMethodsPayload = {
 export interface SavedProto {
   fileName: string;
   filePath: string;
-  protoText?: string;
   imports?: PlaceholderFile[];
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -67,6 +67,14 @@ export interface FileWithImports extends BaseFile {
   missing?: PlaceholderFile[];
 }
 
+export interface Library {
+  isPreloaded?: boolean;
+  version?: string
+  url?: string;
+  name: string;
+  path?: string;
+}
+
 export interface RawPlaceholderFile {
   file_name: string;
   file_path: string;
@@ -74,6 +82,14 @@ export interface RawPlaceholderFile {
   imports?: RawPlaceholderFile[];
   is_library?: boolean;
   url?: string;
+}
+
+export interface RawLibrary {
+  is_preloaded?: boolean;
+  version?: string;
+  url?: string;
+  name: string;
+  path?: string;
 }
 
 export interface EditorTabRequest extends EditorRequest {
@@ -95,6 +111,7 @@ export interface EntitySpec {
   owner: string;
   definition: string;
   files: PlaceholderFile[];
+  libraries?: Library[];
   system?: string;
   targets?: GRPCTarget;
   imports?: PlaceholderFile[];
@@ -108,6 +125,7 @@ export interface RawEntitySpec {
   files: RawPlaceholderFile[];
   system?: string;
   targets?: GRPCTarget;
+  libraries?: RawLibrary[];
   imports?: RawPlaceholderFile[];
 }
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -49,7 +49,9 @@ import {
   UploadProtoResponse,
   EditorTabs,
   PlaceholderFile,
-  RawEntitySpec
+  RawEntitySpec,
+  Library,
+  RawLibrary
 } from '../../api';
 import { arrayMoveImmutable as arrayMove } from '../../utils'
 import { Store } from '../../storage/Store';
@@ -685,6 +687,7 @@ function parseRawEntitySpec(spec?: RawEntitySpec): EntitySpec {
     lifecycle: rawSpec.lifecycle,
     type: rawSpec.type,
     definition: rawSpec.definition,
+    libraries: rawSpec.libraries?.map(mapRawLibrary),
     imports: rawSpec.imports?.map(mapRawPlaceholderFile),
     files: rawSpec.files?.map(mapRawPlaceholderFile) || [],
     targets: rawSpec.targets,
@@ -804,7 +807,22 @@ function handleMethodDoubleClick(editorTabs: EditorTabs, setTabs: React.Dispatch
       tabs: newTabs,
     });
   }
+}
 
+const mapRawLibrary = ({
+  name,
+  path,
+  url,
+  is_preloaded,
+  version,
+}: RawLibrary): Library => {
+  return {
+    path,
+    url,
+    name,
+    isPreloaded: is_preloaded,
+    version
+  }
 }
 
 const mapRawPlaceholderFile = ({

--- a/src/components/App/Editor/ProtoFileViewer.tsx
+++ b/src/components/App/Editor/ProtoFileViewer.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import AceEditor from 'react-ace';
-import { Drawer } from 'antd';
-import { ProtoInfo } from '../../../api';
+import { Drawer, Spin } from 'antd';
+import { grpcPlaygroundApiRef, ProtoInfo } from '../../../api';
+import { useAsyncFn } from 'react-use';
+import { useApi } from '@backstage/core-plugin-api';
 
 interface ProtoFileViewerProps {
   protoInfo: ProtoInfo
@@ -10,6 +12,14 @@ interface ProtoFileViewerProps {
 }
 
 export function ProtoFileViewer({ protoInfo, visible, onClose }: ProtoFileViewerProps) {
+  const grpcPlaygroundApi = useApi(grpcPlaygroundApiRef);
+  const [{ loading, error, value }, getProtoTextAsync] = useAsyncFn(grpcPlaygroundApi.getProtoText, [])
+
+  useEffect(() => {
+    if (visible) {
+      getProtoTextAsync(protoInfo.service.proto.filePath);
+    }
+  }, [visible, protoInfo.service.proto.filePath, getProtoTextAsync]);
 
   return (
     <Drawer
@@ -21,33 +31,37 @@ export function ProtoFileViewer({ protoInfo, visible, onClose }: ProtoFileViewer
       onClose={onClose}
       visible={visible}
     >
-      <AceEditor
-        style={{ 
-          marginTop: "10px",
-          background: "#fff",
-        }}
-        width="100%"
-        height="100%"
-        mode="protobuf"
-        theme="textmate"
-        name="output"
-        fontSize={13}
-        showPrintMargin={false}
-        wrapEnabled
-        showGutter
-        readOnly
-        value={protoInfo.service.proto.protoText}
-        onLoad={(editor: any) => {
-          editor.renderer.$cursorLayer.element.style.display = "none";
-          editor.gotoLine(0, 0, true);
-        }}
-        setOptions={{
-          useWorker: true,
-          displayIndentGuides: false,
-          fixedWidthGutter: true,
-          tabSize: 1,
-        }}
-      />
+      {loading ? (
+        <Spin />
+      ) : (
+        <AceEditor
+          style={{
+            marginTop: "10px",
+            background: "#fff",
+          }}
+          width="100%"
+          height="100%"
+          mode="protobuf"
+          theme="textmate"
+          name="output"
+          fontSize={13}
+          showPrintMargin={false}
+          wrapEnabled
+          showGutter
+          readOnly
+          value={value?.protoText || ''}
+          onLoad={(editor: any) => {
+            editor.renderer.$cursorLayer.element.style.display = "none";
+            editor.gotoLine(0, 0, true);
+          }}
+          setOptions={{
+            useWorker: true,
+            displayIndentGuides: false,
+            fixedWidthGutter: true,
+            tabSize: 1,
+          }}
+        />
+      )}
     </Drawer>
   );
 }


### PR DESCRIPTION
### Breaking changes:

- upgrade dependency to backstage 1.5.0
- ProtoDocViewer now will call POST /proto-text for retrieving proto file text
- Support proto library #9 
  - add support for proto library
  - add example support library google-apis default 
  - example https://github.com/zalopay-oss/backstage-grpc-playground/blob/7945b77db29a91f7c88cc8dbdb75927f9cd8f38f/examples/yaml-definition/libraries.yaml#L17-L20
 
